### PR TITLE
Disable by default the script on unsupported pages, so we can release a version 1.0 on Greasyfork

### DIFF
--- a/JS/KOG.user.js
+++ b/JS/KOG.user.js
@@ -1,11 +1,10 @@
 // ==UserScript==
 // @name         Good Old Kongregate
-// @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Gone but not forgotten
 // @author       Fancy2209, Matrix4348
 // @match        *://www.kongregate.com/*
-// @icon         https://cdn1.kongcdn.com/compiled-assets/favicos/favico-196-de563d6c4856efb7ac5060666510e5e50b2382593b724b802a6c6c53c1971e8c.png
+// @icon         https://matrix4348.github.io/logos/kongregate.png
 // @grant        GM_info
 // @grant        GM_getValue
 // @grant        GM_setValue
@@ -24,11 +23,13 @@ if( typeof(GM_unregisterMenuCommand)=="undefined" ){ GM_unregisterMenuCommand=fu
 
 var unsupported_pages = [
     // Use (|/fr|/de) after .com in order to take localized pages into account.
-    // Notes: . is a wildcard for one character, (?!X) means "only if not followed by X", (.*?) means anything
+    // Notes: . is a wildcard for one character, *represents several occurences of what if follows, (?!X) means "only if not followed by X", (.*?) means anything.
+    // Note: (\[A-Za-z0-9_\]) means anything that is a latin letter, arabic digit or underscore.
     "www.kongregate.com(|/fr|/de)/achievements",
     "www.kongregate.com(|/fr|/de)/search",
     "www.kongregate.com(|/fr|/de)/games(?!/.)",
-    "www.kongregate.com((?!/games/)|/fr(?!/games/)|/de(?!/games/))/(.*?)-games", // Target: pages like https://www.kongregate.com/puzzle-games. Use of (?!/games/) because game names could end by "-games" or " games".
+    "www.kongregate.com((?!/games/)|/fr(?!/games/)|/de(?!/games/))/(.*?)-games", // Targets: pages like https://www.kongregate.com/puzzle-games. Use of (?!/games/) because game names could end by "-games" or " games".
+    "www.kongregate.com(|/fr|/de)/games/(\[A-Za-z0-9_\]*)/?(?!.)", // Targets: www.kongregate.com/games/dev and www.kongregate.com/games/dev/ but not www.kongregate.com/games/dev/game
 ];
 
 function is_unsupported(){
@@ -103,10 +104,8 @@ function TimeToLogin(){
     if(go){
         var e = active_user.getAttributes();
         updateFriendInfo(t), updatePlaylist(), updateFavorites();
-        //var n = new Element("img").writeAttribute({ id: "welcome_box_small_user_avatar", src: e.avatar_url, title: e.username, name: "user_avatar", alt: "Avatar for " + e.username, height: 28, width: 28 });
         var n = document.createElement("img"); n.id = "welcome_box_small_user_avatar"; n.src = e.avatar_url; n.title = e.username; n.name = "user_avatar"; n.alt = "Avatar for " + e.username; n.height = 28; n.width = 28;
         t.down("span#small_avatar_placeholder").update(n),
-        //document.getElementById("small_avatar_placeholder").update(n),
             t.select(".facebook_nav_item").each(function (e) { active_user.isFacebookConnected() && e.hide(); }),
             $("mini-profile-level").writeAttribute({ class: "spritesite levelbug level_" + e.level, title: "Level " + e.level }),
             active_user.populateUserSpecificLinks(t),

--- a/JS/KOG.user.js
+++ b/JS/KOG.user.js
@@ -1,15 +1,71 @@
 // ==UserScript==
 // @name         Good Old Kongregate
 // @namespace    http://tampermonkey.net/
-// @version      0.75
+// @version      1.0
 // @description  Gone but not forgotten
 // @author       Fancy2209, Matrix4348
-// @match         *://www.kongregate.com/*
+// @match        *://www.kongregate.com/*
 // @icon         https://cdn1.kongcdn.com/compiled-assets/favicos/favico-196-de563d6c4856efb7ac5060666510e5e50b2382593b724b802a6c6c53c1971e8c.png
-// @grant        none
+// @grant        GM_info
+// @grant        GM_getValue
+// @grant        GM_setValue
+// @grant        GM_registerMenuCommand
+// @grant        GM_unregisterMenuCommand
 // @run-at       document-start
-// @require      https://code.jquery.com/jquery-1.9.1.js
 // ==/UserScript==
+
+// Various GM_* functions disappeared in Greasemonkey 4 (which is the Greasemonkey for modern Firefox), so we will define them as useless functions so the script does not break.
+// I chose not to make them work in Greasemonkey 4 because the workaround (which is NOT hard to implement) would force us to use async functions in some places. This would, in my opinion, needlessly complexify
+// the code.
+if( typeof(GM_getValue)=="undefined" ){ GM_getValue=function(a,b){ return b; }; }
+if( typeof(GM_setValue)=="undefined" ){ GM_setValue=function(){}; }
+if( typeof(GM_registerMenuCommand)=="undefined" ){ GM_registerMenuCommand=function(){}; }
+if( typeof(GM_unregisterMenuCommand)=="undefined" ){ GM_unregisterMenuCommand=function(){}; }
+
+var unsupported_pages = [
+    // Use (|/fr|/de) after .com in order to take localized pages into account.
+    // Notes: . is a wildcard for one character, (?!X) means "only if not followed by X", (.*?) means anything
+    "www.kongregate.com(|/fr|/de)/achievements",
+    "www.kongregate.com(|/fr|/de)/search",
+    "www.kongregate.com(|/fr|/de)/games(?!/.)",
+    "www.kongregate.com((?!/games/)|/fr(?!/games/)|/de(?!/games/))/(.*?)-games", // Target: pages like https://www.kongregate.com/puzzle-games. Use of (?!/games/) because game names could end by "-games" or " games".
+];
+
+function is_unsupported(){
+    var url=document.location.href;
+    for(let p of unsupported_pages){
+        if(url.search(p)>-1){ return true; }
+    }
+    return false;
+}
+
+function PutWarningOnUnsupportedPages(A){
+    if(typeof(document.body?.firstElementChild)!="undefined" && is_unsupported()){
+        var d=document.createElement("div");
+        d.style.textAlign="center";
+        d.style.margin="5px";
+        d.style.fontSize="12px";
+        d.style.fontStyle="italic";
+        var nv=(GM_info.scriptHandler+GM_info.version).toLowerCase().substring(0,13);
+        var good, bad;
+        good="<b>Good Old Kongregate may completely break this page, therefore it is disabled by default here. However, you can toggle the user script on and off on unsupported pages from the "+GM_info.scriptHandler+" menu (click the extension icon).</b>";
+        bad="<b>Good Old Kongregate has been disabled on this page because it may completely break it.</b>"; // Reminder: on Greasemonkey 4, most GM_ functions do not work.
+        d.innerHTML= nv=="greasemonkey4" ? bad : good;
+        document.body.insertBefore(d,document.body.firstElementChild);
+    }
+    else if(A){ setTimeout(function(B){ PutWarningOnUnsupportedPages(B); },1000, A-1); }
+}
+
+function toggle_command(){
+    var x = { true: "Disable Good Old Kongregate on unsupported pages", false:"Enable Good Old Kongregate on unsupported pages" };
+    var e = GM_getValue("enable_on_unsupported",false);
+    GM_unregisterMenuCommand(x[e]);
+    GM_registerMenuCommand(x[!e],toggle_command,{id:x[!e],autoClose:false});
+    GM_setValue("enable_on_unsupported",!e);
+}
+
+var x = { true: "Disable Good Old Kongregate on unsupported pages", false:"Enable Good Old Kongregate on unsupported pages" };
+GM_registerMenuCommand(x[GM_getValue("enable_on_unsupported",false)],toggle_command,{id:x[GM_getValue("enable_on_unsupported",false)],autoClose:false});
 
 function TimeToLogin(){
     function updatePlaylist() {
@@ -47,8 +103,10 @@ function TimeToLogin(){
     if(go){
         var e = active_user.getAttributes();
         updateFriendInfo(t), updatePlaylist(), updateFavorites();
-        var n = new Element("img").writeAttribute({ id: "welcome_box_small_user_avatar", src: e.avatar_url, title: e.username, name: "user_avatar", alt: "Avatar for " + e.username, height: 28, width: 28 });
+        //var n = new Element("img").writeAttribute({ id: "welcome_box_small_user_avatar", src: e.avatar_url, title: e.username, name: "user_avatar", alt: "Avatar for " + e.username, height: 28, width: 28 });
+        var n = document.createElement("img"); n.id = "welcome_box_small_user_avatar"; n.src = e.avatar_url; n.title = e.username; n.name = "user_avatar"; n.alt = "Avatar for " + e.username; n.height = 28; n.width = 28;
         t.down("span#small_avatar_placeholder").update(n),
+        //document.getElementById("small_avatar_placeholder").update(n),
             t.select(".facebook_nav_item").each(function (e) { active_user.isFacebookConnected() && e.hide(); }),
             $("mini-profile-level").writeAttribute({ class: "spritesite levelbug level_" + e.level, title: "Level " + e.level }),
             active_user.populateUserSpecificLinks(t),
@@ -62,11 +120,12 @@ function TimeToLogin(){
              0 !== active_user.unreadWhispersCount()
              ? $("my-messages-link").setAttribute("href", "/accounts/" + active_user.username() + "/private_messages")
              : 0 !== active_user.unreadGameMessagesCount() && $("my-messages-link").setAttribute("href", "/accounts/" + active_user.username() + "/game_messages")),
-            null !== active_user.chipsBalance() , ($("blocks_balance").update(active_user.chipsBalance()), $("blocks").show()),
+            null !== active_user.chipsBalance(),
+            ($("blocks_balance").update(active_user.chipsBalance()), $("blocks").show()),
             $("guest_user_welcome_content").hide(),
             $("nav_welcome_box").show();
     }
-    else{ setTimeout(function(){ TimeToLogin(); },10000); }
+    else{ setTimeout(function(){ TimeToLogin(); },1); }
 }
 
 function ReopenChat(A){
@@ -149,6 +208,7 @@ function replace_favicon(){
 }
 
 function ThingsToDoAtTheEnd(){
+    PutWarningOnUnsupportedPages(50);
     ReopenChat(50);
 };
 
@@ -763,7 +823,7 @@ $j( document ).ready(function() {
 </a>
 <ul class="footer_sub clearfix">
 <li class="kongregate_copyright">
-  <span>© 2023 </span>
+  <span>© 2024 </span>
   <a class="spriteall spritesite" href="https://www.kongregate.com/">Kongregate</a>
 </li>
 <li class="footer_mtg--logo spritesite textreplace">An MTG company</li>
@@ -864,51 +924,7 @@ kong_ads.displayAd("kong_home_af_728x90");}
   <li class="prev"></li>
   <li class="next mls"></li>
 </ol>
-<ul class="home_feat_items">
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-Kreds { background:#F5BF41 url('https://cdn3.kongcdn.com/assets/files/0002/8834/KONG_Offerwall_2XCopy_FeatureRoll_2880x650_en_none.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">Kreds</h3> <a href="https://www.kongregate.com/kreds?haref=FR_Kreds" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-Kreds"></div>
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-RaidHeroesTotalWar { background:#121721 url('https://cdn3.kongcdn.com/assets/files/0002/8818/RHTW.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">RaidHeroesTotalWar</h3> <a href="https://www.kongregate.com/games/thekastudio/raid-heroes-total-war?haref=FR_RaidHeroesTotalWar" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-RaidHeroesTotalWar"></div>
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-DungeonCrusherSoulHunters { background:#311B3E url('https://cdn1.kongcdn.com/assets/files/0002/8819/DC.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">DungeonCrusherSoulHunters</h3> <a href="https://www.kongregate.com/games/towardsmars/dungeon-crusher-soul-hunters?haref=FR_DungeonCrusherSoulHunters" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-DungeonCrusherSoulHunters"></div>
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-FirestoneIdleRPG { background:#301D48 url('https://cdn4.kongcdn.com/assets/files/0002/8817/kongregateFeaturedBannerHalloween.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">FirestoneIdleRPG</h3> <a href="https://www.kongregate.com/games/HolydayStudios/firestone?haref=FR_FirestoneIdleRPG" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-FirestoneIdleRPG"></div>
-
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-MedievalChronicles7 { background:#C34C46 url('https://cdn1.kongcdn.com/assets/files/0002/8839/SUN_HD.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace"> MedievalChronicles7 </h3> <a href="https://www.kongregate.com/games/VasantJ/medieval-chronicles-7?haref=FR_ MedievalChronicles7" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-MedievalChronicles7"></div>
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content focus">
-  <style> .fr-template-1layer-bg-Discord { background:#202939 url('https://cdn1.kongcdn.com/assets/files/0002/8802/frankongstein_feature_roll.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">Discord</h3> <a href="https://discord.gg/Kongregate" target="_blank" class="click_link">Create a Kongpanion and share with our community!</a> </div> <div class="bg fr-template-1layer-bg-Discord"></div>
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-BHQ { background:#1B0D28 url('https://cdn2.kongcdn.com/assets/files/0002/8821/getspookywithbhq_banner.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">BHQ</h3> <a href="https://www.kongregate.com/games/Juppiomenz/bit-heroes?haref=FR_BHQ" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-BHQ"></div>
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-AnimationThrowdown { background:#A1D6EF url('https://cdn3.kongcdn.com/assets/files/0002/8810/AT_FeatureRoll_2880X650.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">AnimationThrowdown</h3> <a href="https://www.kongregate.com/games/Throwdown/animation-throwdown?haref=FR_AnimationThrowdown" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-AnimationThrowdown"></div>
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-MergestKingdom { background:#7275AF url('https://cdn3.kongcdn.com/assets/files/0002/8822/2280x650_kingdom.jpg') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">MergestKingdom</h3> <a href="https://www.kongregate.com/games/CleverApps/mergest-kingdom?haref=FR_MergestKingdom" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-MergestKingdom"></div>
-</li>
-
-        <li data-guest-only="false" data-country-code="non_targeted" data-locale="global" class="home_feat_item featured_content">
-  <style> .fr-template-1layer-bg-Vinterget { background:#7D8A9F url('https://cdn2.kongcdn.com/assets/files/0002/8816/KongregatePic__1_.png') no-repeat 0 50%; } </style> <div class="copy click_box"> <h3 class="textreplace">Vinterget</h3> <a href="https://www.kongregate.com/games/ailwuful/vinterget?haref=FR_Vinterget" target="_blank" class="click_link">Play Now!</a> </div> <div class="bg fr-template-1layer-bg-Vinterget"></div>
-</li>
-
-
-
-  </ul>
+<ul class="home_feat_items"></ul>
 </div>
 
   <!-- Pod Container Start -->
@@ -2884,72 +2900,78 @@ kong_ads.displayAd("kong_home_bf_281x90_3");
     var targetNode = document;
     var config = { childList: true, subtree: true };
     var callback = (mutationList, observer) => {
-        for (let mutation of mutationList) {
-            for(let node of mutation.addedNodes){
-                for (let mutation of mutationList) {
-                    if (mutation.type === 'childList') {
-                        for(let node of mutation.addedNodes){
-                            if(v1==0 && node.tagName=="K-NAVBAR"){
-                                v1=1;
-                                let n=document.createElement("div");
-                                n.id="headerwrap";
-                                n.innerHTML = headerWrap;
-                                node.parentElement.insertBefore(n, node);
-                                node.remove();
-                                TimeToLogin();
-                                fill_games_tab(50);
-                                replace_css();
-                                replace_favicon();
-                            }
-                            else if(v1==1 && node.tagName=="K-NAVBAR"){
-                                node.remove();
-                            }
-                            else if(v2==0 && node.id=="footer" && node.tagName=="K-FOOTER"){
-                                v2=1;
-                                let n=document.createElement("div");
-                                n.id="footer";
-                                n.addClassName("clearfix");
-                                n.innerHTML = footer;
-                                node.parentElement.insertBefore(n, node);
-                                node.remove();
-                            }
-                            else if (v3==0 && 0==1){
-                                v3=1;
-                                // FREE
-                            }
-                            else if (v4==0 && 0==1){
-                                v4=1;
-                                // FREE
-                            }
-                            else if(v5==0 && node.id=="floating_game_holder"){ // MORE WORK NEEDED TO FIX CHANGEs FROM DECEMBER 14TH!
-                                v5=1;
-                                document.getElementById("floating_game_holder").parentNode.style.backgroundColor="#2b2b2b";
-                            }
-                            else if(v6==0 && 0==1){
-                                v6=1;
-                                // FREE
-                            }
-                            else if(v7==0 && 0==1){
-                                v7=1;
-                                // FREE
-                            }
-                            else if(v8==0 && document.URL=="https://www.kongregate.com/" && node.tagName=="MAIN"){
-                                v8=1;
-                                let pw=document.createElement("div");
-                                pw.id="primarywrap";
-                                pw.addClassName("divider");
-                                pw.innerHTML=homepage_primarywrap;
-                                node.parentElement.insertBefore(pw, node);
-                                node.remove();
-                            }
-                            else if(v9==0 && node==document.body && document.getElementById("home")){
-                                v9=1;
-                                node.classList.remove('lang_other', 'lang_en');
-                                node.classList.add('new_home', 'no_subwrap', 'grid960');
-                            }
-                            else if(v10==0 && (node.src||"").search("konstruct.min.js")>-1){
-                                v10=1;
-                                node.remove();
+        if( !is_unsupported() || GM_getValue("enable_on_unsupported",false) ){
+            for (let mutation of mutationList) {
+                for(let node of mutation.addedNodes){
+                    for (let mutation of mutationList) {
+                        if (mutation.type === 'childList') {
+                            for(let node of mutation.addedNodes){
+                                if(v1==0 && node.tagName=="K-NAVBAR"){
+                                    v1=1;
+                                    let n=document.createElement("div");
+                                    n.id="headerwrap";
+                                    n.innerHTML = headerWrap;
+                                    node.parentElement.insertBefore(n, node);
+                                    node.remove();
+                                    TimeToLogin();
+                                    fill_games_tab(50);
+                                    replace_css();
+                                    replace_favicon();
+                                }
+                                else if(v1==1 && node.tagName=="K-NAVBAR"){
+                                    node.remove();
+                                    // Note: sitewide_javascripts will raise the following exception: Uncaught TypeError: t(...).parentNode is null
+                                    // This does not seem to cause any issue besides polluting the console.
+                                }
+                                else if(v2==0 && node.id=="footer" && node.tagName=="K-FOOTER"){
+                                    v2=1;
+                                    let n=document.createElement("div");
+                                    n.id="footer";
+                                    n.addClassName("clearfix");
+                                    n.innerHTML = footer;
+                                    node.parentElement.insertBefore(n, node);
+                                    node.remove();
+                                }
+                                else if (v3==0 && 0==1){
+                                    v3=1;
+                                    // FREE
+                                }
+                                else if (v4==0 && 0==1){
+                                    v4=1;
+                                    // FREE
+                                }
+                                else if(v5==0 && node.id=="floating_game_holder"){ // MORE WORK NEEDED TO FIX CHANGEs FROM DECEMBER 14TH!
+                                    v5=1;
+                                    document.getElementById("floating_game_holder").parentNode.style.backgroundColor="#2b2b2b";
+                                }
+                                else if(v6==0 && 0==1){
+                                    v6=1;
+                                    // FREE
+                                }
+                                else if(v7==0 && 0==1){
+                                    v7=1;
+                                    // FREE
+                                }
+                                else if(v8==0 && document.URL=="https://www.kongregate.com/" && node.tagName=="MAIN"){
+                                    v8=1;
+                                    let pw=document.createElement("div");
+                                    pw.id="primarywrap";
+                                    pw.addClassName("divider");
+                                    let banners=node.getElementsByClassName("home_feat_items")[0].innerHTML;
+                                    pw.innerHTML=homepage_primarywrap;
+                                    node.parentElement.insertBefore(pw, node);
+                                    node.remove();
+                                    document.getElementsByClassName("home_feat_items")[0].innerHTML=banners;
+                                }
+                                else if(v9==0 && node==document.body && document.getElementById("home")){
+                                    v9=1;
+                                    node.classList.remove('lang_other', 'lang_en');
+                                    node.classList.add('new_home', 'no_subwrap', 'grid960');
+                                }
+                                else if(v10==0 && (node.src||"").search("konstruct.min.js")>-1){
+                                    v10=1;
+                                    node.remove();
+                                }
                             }
                         }
                     }

--- a/JS/KOG.user.js
+++ b/JS/KOG.user.js
@@ -49,8 +49,8 @@ function PutWarningOnUnsupportedPages(A){
         d.style.fontStyle="italic";
         var nv=(GM_info.scriptHandler+GM_info.version).toLowerCase().substring(0,13);
         var good, bad;
-        good="<b>Good Old Kongregate may completely break this page, therefore it is disabled by default here. However, you can toggle the user script on and off on unsupported pages from the "+GM_info.scriptHandler+" menu (click the extension icon).</b>";
-        bad="<b>Good Old Kongregate has been disabled on this page because it may completely break it.</b>"; // Reminder: on Greasemonkey 4, most GM_ functions do not work.
+        good="<b>Good Old Kongregate is partly disabled by default on this page because some of its features might completely break it. However, you can toggle the full user script on and off on unsupported pages from the "+GM_info.scriptHandler+" menu (click the extension icon or right click the page).</b>";
+        bad="<b>Good Old Kongregate is partly disabled by default on this page because some of its features might completely break it.</b>"; // Reminder: on Greasemonkey 4, most GM_ functions do not work.
         d.innerHTML= nv=="greasemonkey4" ? bad : good;
         document.body.insertBefore(d,document.body.firstElementChild);
     }
@@ -173,11 +173,11 @@ function fill_games_tab(A){
     else if(A){ setTimeout(function(B){ fill_games_tab(B); },1000, A-1); }
 }
 
-function replace_css(){
+function replace_css(remove_new){
     var N=document.head.getElementsBySelector('link[rel="stylesheet"]');
     for(let n of N){
         if(n.href.search("gamepage_merged")>-1 && n.getAttribute("data-turbo-track")=="reload"){
-            n.remove();
+            if(remove_new){ n.remove(); }
             let goodKongCSS = document.createElement('link');
             goodKongCSS.rel = 'stylesheet';
             goodKongCSS.setAttribute('data-turbo-track', 'reload');
@@ -185,7 +185,7 @@ function replace_css(){
             document.head.appendChild(goodKongCSS);
         }
         else if(n.href.search("application_merged")>-1 && n.getAttribute("data-turbo-track")=="reload"){
-            n.remove();
+            if(remove_new){ n.remove(); }
             let goodKongCSS = document.createElement('link');
             goodKongCSS.rel = 'stylesheet';
             goodKongCSS.setAttribute('data-turbo-track', 'reload');
@@ -193,7 +193,7 @@ function replace_css(){
             document.head.appendChild(goodKongCSS);
         }
         else if(n.href.search("application-")>-1 && n.getAttribute("data-turbo-track")=="reload"){
-            n.remove();
+            if(remove_new){ n.remove(); }
         }
     }
 }
@@ -2899,76 +2899,76 @@ kong_ads.displayAd("kong_home_bf_281x90_3");
     var targetNode = document;
     var config = { childList: true, subtree: true };
     var callback = (mutationList, observer) => {
-        if( !is_unsupported() || GM_getValue("enable_on_unsupported",false) ){
-            for (let mutation of mutationList) {
-                for(let node of mutation.addedNodes){
-                    for (let mutation of mutationList) {
-                        if (mutation.type === 'childList') {
-                            for(let node of mutation.addedNodes){
-                                if(v1==0 && node.tagName=="K-NAVBAR"){
-                                    v1=1;
-                                    let n=document.createElement("div");
-                                    n.id="headerwrap";
-                                    n.innerHTML = headerWrap;
-                                    node.parentElement.insertBefore(n, node);
-                                    node.remove();
-                                    TimeToLogin();
-                                    fill_games_tab(50);
-                                    replace_css();
-                                    replace_favicon();
-                                }
-                                else if(v1==1 && node.tagName=="K-NAVBAR"){
-                                    node.remove();
-                                    // Note: sitewide_javascripts will raise the following exception: Uncaught TypeError: t(...).parentNode is null
-                                    // This does not seem to cause any issue besides polluting the console.
-                                }
-                                else if(v2==0 && node.id=="footer" && node.tagName=="K-FOOTER"){
-                                    v2=1;
-                                    let n=document.createElement("div");
-                                    n.id="footer";
-                                    n.addClassName("clearfix");
-                                    n.innerHTML = footer;
-                                    node.parentElement.insertBefore(n, node);
-                                    node.remove();
-                                }
-                                else if (v3==0 && 0==1){
-                                    v3=1;
-                                    // FREE
-                                }
-                                else if (v4==0 && 0==1){
-                                    v4=1;
-                                    // FREE
-                                }
-                                else if(v5==0 && node.id=="floating_game_holder"){ // MORE WORK NEEDED TO FIX CHANGEs FROM DECEMBER 14TH!
-                                    v5=1;
-                                    document.getElementById("floating_game_holder").parentNode.style.backgroundColor="#2b2b2b";
-                                }
-                                else if(v6==0 && 0==1){
-                                    v6=1;
-                                    // FREE
-                                }
-                                else if(v7==0 && 0==1){
-                                    v7=1;
-                                    // FREE
-                                }
-                                else if(v8==0 && document.URL=="https://www.kongregate.com/" && node.tagName=="MAIN"){
-                                    v8=1;
-                                    let pw=document.createElement("div");
-                                    pw.id="primarywrap";
-                                    pw.addClassName("divider");
-                                    let banners=node.getElementsByClassName("home_feat_items")[0].innerHTML;
-                                    pw.innerHTML=homepage_primarywrap;
-                                    node.parentElement.insertBefore(pw, node);
-                                    node.remove();
-                                    document.getElementsByClassName("home_feat_items")[0].innerHTML=banners;
-                                }
-                                else if(v9==0 && node==document.body && document.getElementById("home")){
-                                    v9=1;
-                                    node.classList.remove('lang_other', 'lang_en');
-                                    node.classList.add('new_home', 'no_subwrap', 'grid960');
-                                }
-                                else if(v10==0 && (node.src||"").search("konstruct.min.js")>-1){
-                                    v10=1;
+        for (let mutation of mutationList) {
+            for(let node of mutation.addedNodes){
+                for (let mutation of mutationList) {
+                    if (mutation.type === 'childList') {
+                        for(let node of mutation.addedNodes){
+                            if(v1==0 && node.tagName=="K-NAVBAR"){
+                                v1=1;
+                                let n=document.createElement("div");
+                                n.id="headerwrap";
+                                n.innerHTML = headerWrap;
+                                node.parentElement.insertBefore(n, node);
+                                node.remove();
+                                TimeToLogin();
+                                fill_games_tab(50);
+                                replace_css(!is_unsupported() || GM_getValue("enable_on_unsupported",false));
+                                replace_favicon();
+                            }
+                            else if(v1==1 && node.tagName=="K-NAVBAR"){
+                                node.remove();
+                                // Note: sitewide_javascripts will raise the following exception: Uncaught TypeError: t(...).parentNode is null
+                                // This does not seem to cause any issue besides polluting the console.
+                            }
+                            else if(v2==0 && node.id=="footer" && node.tagName=="K-FOOTER"){
+                                v2=1;
+                                let n=document.createElement("div");
+                                n.id="footer";
+                                n.addClassName("clearfix");
+                                n.innerHTML = footer;
+                                node.parentElement.insertBefore(n, node);
+                                node.remove();
+                            }
+                            else if (v3==0 && 0==1){
+                                v3=1;
+                                // FREE
+                            }
+                            else if (v4==0 && 0==1){
+                                v4=1;
+                                // FREE
+                            }
+                            else if(v5==0 && node.id=="floating_game_holder"){ // MORE WORK NEEDED TO FIX CHANGEs FROM DECEMBER 14TH!
+                                v5=1;
+                                document.getElementById("floating_game_holder").parentNode.style.backgroundColor="#2b2b2b";
+                            }
+                            else if(v6==0 && 0==1){
+                                v6=1;
+                                // FREE
+                            }
+                            else if(v7==0 && 0==1){
+                                v7=1;
+                                // FREE
+                            }
+                            else if(v8==0 && document.URL=="https://www.kongregate.com/" && node.tagName=="MAIN"){
+                                v8=1;
+                                let pw=document.createElement("div");
+                                pw.id="primarywrap";
+                                pw.addClassName("divider");
+                                let banners=node.getElementsByClassName("home_feat_items")[0].innerHTML;
+                                pw.innerHTML=homepage_primarywrap;
+                                node.parentElement.insertBefore(pw, node);
+                                node.remove();
+                                document.getElementsByClassName("home_feat_items")[0].innerHTML=banners;
+                            }
+                            else if(v9==0 && node==document.body && document.getElementById("home")){
+                                v9=1;
+                                node.classList.remove('lang_other', 'lang_en');
+                                node.classList.add('new_home', 'no_subwrap', 'grid960');
+                            }
+                            else if(v10==0 && (node.src||"").search("konstruct.min.js")>-1){
+                                v10=1;
+                                if( !is_unsupported() || GM_getValue("enable_on_unsupported",false) ){
                                     node.remove();
                                 }
                             }

--- a/JS/greasyfork_additional_info.md
+++ b/JS/greasyfork_additional_info.md
@@ -1,0 +1,7 @@
+**Before installing this script, make sure that you have installed (and enabled) a user script manager (a browser extension such as Tampermonkey, Violentmonkey, Greasymonkey or another monkey).**
+
+Good Old Kongregate makes Kongregate look as it did before 2023, as if the atrocious "redesign" never occured.
+
+The script is not finished because we lack the time, so feel free to help us on [GitHub](https://github.com/Fancy2209/Good-Old-Kongregate). In the meanwhile, a lot of pages are already being displayed almost perfectly, including the most important ones: the game pages! A few sets of pages are completely broken, however, so the script is disabled by default on them.
+
+Written by [Fancy2209](https://github.com/Fancy2209) and [Matrix4348](https://www.kongregate.com/accounts/Matrix4348).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Good-Old-Kongregate
 Make Kongregate look like the Good Old Days!
+By [Fancy2209](https://github.com/Fancy2209) and [Matrix4348](https://www.kongregate.com/accounts/Matrix4348)
+## 
+This repository is for developing Good Old Kongregate, a user script aiming to revert the atrocious Kongregate "redesign" from 2023 and beyond, with what existed prior to those dark times.
+There is still a lot of work left to do, as some pages like the achievements, games (the list of games on the site, not games themselves) and search pages are completely broken with the script. They need further attention.
+Any help would be much welcome, and greatly appreciated.
 
-By [Fancy2209](https://github.com/Fancy2209) and [Matrix4348](https://github.com/Matrix4348)
+To install the user script, please go to [Greasyfork](https://greasyfork.org/en/scripts?q=Kongregate)


### PR DESCRIPTION
I know that you wanted to fix other things before uploading it to Greasyfork, Fancy, but the project has been stalling. Instead, I suggest that we disable the user script on completely broken pages (with a way to re-enable it on users' end) so it does not look like a complete draft. Once it is properly shareable with a page on Greasyfork, we might attract more contributors (granted, the odd is almost zilch).
After this pull request is merged, you can set up everything on your end: https://greasyfork.org/en/users/webhook-info

What did I add? Well, a toggle in the extension menu for the users to still activate the script on broken pages, by default disabled.
Almost nothing runs when disabled, but I have actually a question: should we still replace headers and footers, as these would not be broken? Note that they would use the new css but with old html (in other words, what we got at the beginning of 2023, before they vomit their konstruct thing).
I have also removed the jquery `@require` because it breaks things when `@grant` is set to anything other than none. Anyway, it turned out that we no longer need it.

I am not completely done yet, but I wanted your input on the matter.

To-do list:
- [x] updating the README
- [x] creating a file that Greasyfork would synchronize with for the script description on the script page (so everything can be updated on GitHub)
- [x] add pages such as `www.kongregate.com/games/dev` and `www.kongregate.com/games/dev/` as unsupported